### PR TITLE
Only delete unique history if queue is deleted

### DIFF
--- a/lib/sidekiq-unique-jobs/middleware/client/unique_jobs.rb
+++ b/lib/sidekiq-unique-jobs/middleware/client/unique_jobs.rb
@@ -56,7 +56,7 @@ module SidekiqUniqueJobs
           # remove all unique keys for this queue if queue deleted
           queue = item['queue']
           Sidekiq.redis do |conn|
-            if !conn.exists("queue:#{queue}")
+            if conn.exists('queues') && !conn.sismember('queues', queue)
               # there is no queue, remove all uique keys
               prefix = SidekiqUniqueJobs::PayloadHelper.payload_prefix(queue)
               conn.keys("#{prefix}*").each do |key|


### PR DESCRIPTION
"queue:#{queue}" key is being deleted when all jobs are processed by
sidekiq which incorrectly triggers unique history deletion
